### PR TITLE
chore(ci): add commitlint config rules

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,15 @@
+import conventional from "@commitlint/config-conventional";
+
+export default {
+  ...conventional,
+  rules: {
+    "header-max-length": [2, "always", 80],
+    "body-max-line-length": [2, "always", 80],
+  },
+  ignores: [
+    // skip any commit whose body contains the Dependabot signature
+    (message) => message.includes("Signed‑off‑by: dependabot[bot]"),
+    // skip any Dependabot‑style bump header
+    (message) => /^chore\(deps(-dev)?\): bump /.test(message),
+  ],
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a commit message linting configuration to enforce stricter formatting rules, with automatic exemptions for Dependabot-generated commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->