### PR TITLE
chore(ci): update ignores for Dependabot-style commits

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -7,9 +7,8 @@ export default {
     "body-max-line-length": [2, "always", 80],
   },
   ignores: [
-    // skip any commit whose body contains the Dependabot signature
-    (message) => message.includes("Signed‑off‑by: dependabot[bot]"),
-    // skip any Dependabot‑style bump header
+    // bypass Dependabot-style commits
     (message) => /^chore\(deps(-dev)?\): bump /.test(message),
+    (message) => /Signed-off-by: dependabot\[bot\]/.test(message),
   ],
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration for commit message linting to standardize and reorder rules for ignoring Dependabot commits. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->