### PR TITLE
chore(ci): limit container job to master branch pushes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -109,6 +109,7 @@ jobs:
   container:
     needs: coverage
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
     permissions:
       contents: read
@@ -128,12 +129,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image to GHCR
+      - name: Build and push Docker image to GitHub Container Registry
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          platforms: linux/amd64
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ env.PACKAGE_NAME }}:latest
-            ghcr.io/${{ env.PACKAGE_NAME }}:main
             ghcr.io/${{ env.PACKAGE_NAME }}:sha-${{ github.sha }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to only run Docker container jobs on push events to the master branch.
  - Renamed Docker image build and push step for improved clarity.
  - Enhanced Docker build configuration with explicit platform targeting, cache usage, and adjusted tagging strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->