### PR TITLE
chore(ci): pin GitHub Actions to specific versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     directory: "/src/Dotnet.Samples.AspNetCore.WebApi"
     schedule:
       interval: "daily"
+    commit-message:
+      include: scope
+      prefix: "chore(deps): bump "
     groups:
       efcore:
         patterns:
@@ -18,8 +21,14 @@ updates:
     directory: "/test/Dotnet.Samples.AspNetCore.WebApi.Tests"
     schedule:
       interval: "daily"
+    commit-message:
+      include: scope
+      prefix: "chore(deps): bump "
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      include: scope
+      prefix: "chore(deps): bump "

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Set up .NET ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v4.3.1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
           # The action searches for packages.lock.json in the repository root,
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@v6.2.1
 
       - name: Run tests and generate Cobertura coverage reports
         run: dotnet test --results-directory "coverage" --collect:"XPlat Code Coverage" --settings .runsettings
@@ -71,7 +71,7 @@ jobs:
         run: cat coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Cobertura coverage report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: cobertura.xml
           path: coverage/cobertura.xml
@@ -84,10 +84,10 @@ jobs:
         service: [codecov, codacy]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Download Cobertura coverage report artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.3.0
         with:
           name: cobertura.xml
 
@@ -117,20 +117,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.10.0
 
       - name: Build and push Docker image to GitHub Container Registry
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v6.17.0
         with:
           context: .
           push: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions in the workflow to use the latest stable versions for improved reliability.
  - Standardized Dependabot commit messages for dependency updates to ensure consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->