### PR TITLE
fix: add RequestDelegate to ExceptionMiddleware constructor

### DIFF
--- a/src/Dotnet.Samples.AspNetCore.WebApi/Middlewares/ExceptionMiddleware.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Middlewares/ExceptionMiddleware.cs
@@ -8,7 +8,11 @@ namespace Dotnet.Samples.AspNetCore.WebApi.Middlewares;
 /// <summary>
 /// Middleware for global exception handling with RFC 7807 Problem Details format.
 /// </summary>
-public class ExceptionMiddleware(ILogger<ExceptionMiddleware> logger, IHostEnvironment environment)
+public class ExceptionMiddleware(
+    RequestDelegate next,
+    ILogger<ExceptionMiddleware> logger,
+    IHostEnvironment environment
+)
 {
     private const string ProblemDetailsContentType = "application/problem+json";
 
@@ -18,7 +22,7 @@ public class ExceptionMiddleware(ILogger<ExceptionMiddleware> logger, IHostEnvir
     /// <summary>
     /// Invokes the middleware to handle exceptions globally.
     /// </summary>
-    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    public async Task InvokeAsync(HttpContext context)
     {
         try
         {


### PR DESCRIPTION
The middleware was using primary constructor syntax but was missing the RequestDelegate next parameter, causing dependency injection to fail at runtime with InvalidOperationException.

Fixed by adding RequestDelegate next as the first parameter in the primary constructor and removing it from InvokeAsync method signature, which is the correct pattern for ASP.NET Core middleware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to exception handling middleware architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->