### PR TITLE
ci: move workflow permissions to job level

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,9 +3,6 @@
 
 name: .NET CI
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [ "master" ]
@@ -19,6 +16,8 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.1
@@ -45,6 +44,8 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.1
@@ -79,6 +80,8 @@ jobs:
   coverage:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         service: [codecov, codacy]


### PR DESCRIPTION
Move 'contents: read' permission from workflow level to individual job level for better clarity and following the principle of least privilege. Each job now explicitly declares its required permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security and maintainability by restructuring permission assignments from global workflow-level settings to granular, job-specific permissions for build, test, and coverage processes. This ensures each job operates with only the permissions it requires, improving overall security practices and workflow organization throughout the continuous integration pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->