### PR TITLE
chore: group related packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     commit-message:
       include: scope
       prefix: "chore(deps): "
+    # Pin AutoMapper to 14.x line to avoid commercial v15.x upgrades
     ignore:
       - dependency-name: "AutoMapper"
         update-types: ["version-update:semver-major"]
@@ -16,6 +17,15 @@ updates:
       serilog:
         patterns:
           - "Serilog*"
+      entity-framework:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+      aspnetcore:
+        patterns:
+          - "Microsoft.AspNetCore*"
+      fluentvalidation:
+        patterns:
+          - "FluentValidation*"
 
   - package-ecosystem: "nuget"
     directory: "/test/Dotnet.Samples.AspNetCore.WebApi.Tests"
@@ -24,6 +34,7 @@ updates:
     commit-message:
       include: scope
       prefix: "chore(deps): "
+    # Pin AutoMapper to 14.x line to avoid commercial v15.x upgrades
     ignore:
       - dependency-name: "AutoMapper"
         update-types: ["version-update:semver-major"]
@@ -31,6 +42,9 @@ updates:
       xunit:
         patterns:
           - "xunit*"
+      entity-framework:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- Add entity-framework group for Microsoft.EntityFrameworkCore.*
- Add aspnetcore group for Microsoft.AspNetCore.*
- Add fluentvalidation group for FluentValidation.*

This prevents dependency conflicts by ensuring related packages update together in a single PR instead of separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to organize NuGet packages into logical groups (EntityFrameworkCore, AspNetCore, FluentValidation) for improved update tracking and maintenance workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->