### PR TITLE
docs: prepare changelog for v2.1.0-dusseldorf release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ---
 
 ## [2.1.0 - dusseldorf] - 2026-03-29
@@ -202,7 +210,8 @@ The CD workflow automatically:
 
 ---
 
-[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.0.0-centenario...HEAD
+[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.0-dusseldorf...HEAD
+[2.1.0 - dusseldorf]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.0.0-centenario...v2.1.0-dusseldorf
 [2.0.0 - centenario]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v1.1.0-bernabeu...v2.0.0-centenario
 [1.1.0 - bernabeu]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v1.0.0-azteca...v1.1.0-bernabeu
 [1.0.0 - azteca]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/releases/tag/v1.0.0-azteca


### PR DESCRIPTION
## Summary

- Update `CHANGELOG.md`: promote `[Unreleased]` to `[2.1.0 - dusseldorf] - 2026-03-29`

## Test plan

- [ ] CI passes
- [ ] Merge to master
- [ ] Push tag `v2.1.0-dusseldorf` to trigger CD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version 2.1.0 "dusseldorf" release documented in changelog (March 29, 2026).

* **Chores**
  * Code quality tooling configuration updated for enhanced analysis coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->