### PR TITLE
fix(api): return 200 OK on empty collection and ignore Id in AutoMapper (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Fixed
 
+- `GET /players` now returns `200 OK` with an empty list `[]` when no players exist, instead of `404 Not Found` (#425)
+- AutoMapper `Player → PlayerResponseModel` profile now explicitly ignores the `Id` source member via `ForSourceMember`, making the exclusion intentional rather than implicit (#425)
+
 ### Removed
 
 ---

--- a/src/Dotnet.Samples.AspNetCore.WebApi/Controllers/PlayerController.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Controllers/PlayerController.cs
@@ -69,7 +69,7 @@ public class PlayerController(
                     Title = "Conflict",
                     Status = StatusCodes.Status409Conflict,
                     Detail = $"Player with Squad Number '{player.SquadNumber}' already exists.",
-                    Instance = HttpContext?.Request?.Path.ToString()
+                    Instance = HttpContext?.Request?.Path.ToString(),
                 }
             );
         }
@@ -92,29 +92,15 @@ public class PlayerController(
     /// Retrieves all Players
     /// </summary>
     /// <response code="200">OK</response>
-    /// <response code="404">Not Found</response>
     [HttpGet(Name = "Retrieve")]
     [ProducesResponseType<PlayerResponseModel>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
     public async Task<IResult> GetAsync()
     {
         var players = await playerService.RetrieveAsync();
 
-        if (players.Count > 0)
-        {
-            logger.LogInformation("GET /players retrieved");
-            return TypedResults.Ok(players);
-        }
-        else
-        {
-            logger.LogWarning("GET /players not found");
-            return TypedResults.Problem(
-                statusCode: StatusCodes.Status404NotFound,
-                title: NotFoundTitle,
-                detail: "No players were found.",
-                instance: HttpContext?.Request?.Path.ToString()
-            );
-        }
+        logger.LogInformation("GET /players retrieved {Count} player(s)", players.Count);
+
+        return TypedResults.Ok(players);
     }
 
     /// <summary>

--- a/src/Dotnet.Samples.AspNetCore.WebApi/Mappings/PlayerMappingProfile.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Mappings/PlayerMappingProfile.cs
@@ -28,6 +28,7 @@ public class PlayerMappingProfile : Profile
 
         // Player → PlayerResponseModel
         CreateMap<Player, PlayerResponseModel>()
+            .ForSourceMember(source => source.Id, options => options.DoNotValidate())
             .ForMember(
                 destination => destination.FullName,
                 options =>

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
@@ -183,7 +183,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Get_Players_NonExisting_Returns404NotFound()
+    public async Task Get_Players_Empty_Returns200OkWithEmptyList()
     {
         // Arrange
         var (service, logger, validator) = PlayerMocks.InitControllerMocks();
@@ -196,8 +196,9 @@ public class PlayerControllerTests : IDisposable
 
         // Assert
         service.Verify(service => service.RetrieveAsync(), Times.Once);
-        var httpResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
-        httpResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        var httpResult = result.Should().BeOfType<Ok<List<PlayerResponseModel>>>().Subject;
+        httpResult.StatusCode.Should().Be(StatusCodes.Status200OK);
+        httpResult.Value.Should().NotBeNull().And.BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- `GET /players` now returns `200 OK []` when no players exist instead of `404 Not Found`
- AutoMapper `Player → PlayerResponseModel` profile explicitly ignores the `Id` source member via `ForSourceMember`, making the exclusion intentional and future-proof
- Updated controller test: `Get_Players_NonExisting_Returns404NotFound` → `Get_Players_Empty_Returns200OkWithEmptyList`

## Test plan

- [x] `GET /players` returns `200 OK` with `[]` when collection is empty
- [x] `GET /players` returns `200 OK` with player list when players exist
- [x] AutoMapper profile compiles and all 39 tests pass
- [x] `dotnet build --configuration Release` succeeds
- [x] CSharpier check passes

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - The `/players` endpoint now returns HTTP 200 OK with an empty list when no players exist, instead of HTTP 404 Not Found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->