### PR TITLE
test(controller): normalize data-state vocabulary in tests (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 - Rename `ValidateAsync_SquadNumber_BelongsToPlayerBeingUpdated_ReturnsNoErrors` to `ValidateAsync_SquadNumberBelongsToPlayerBeingUpdated_ReturnsNoErrors` to align with the 3-segment naming convention for service/validator tests (#427)
 - Make CSharpier step in `/pre-commit` conditional (skip with a note if not installed), consistent with the Docker and CodeRabbit steps (#427)
 - Add "Verify tag commit is reachable from master" step to CD workflow using `git merge-base --is-ancestor` before any build or publish steps (#439)
+- Rename five controller test methods to normalize data-state vocabulary: `NonExisting` → `Nonexistent` for the POST 201 scenario, `NonExisting` → `Unknown` for the four 404-by-lookup scenarios (#452)
+- Add XML doc `<remarks>` block to `PlayerFakes` documenting the three-term data-state vocabulary (`existing`, `nonexistent`, `unknown`) (#452)
 
 ### Fixed
 

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
@@ -109,7 +109,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Post_Players_NonExisting_Returns201Created()
+    public async Task Post_Players_Nonexistent_Returns201Created()
     {
         // Arrange
         var request = PlayerFakes.MakeRequestModelForCreate();
@@ -203,7 +203,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Get_PlayerById_NonExisting_Returns404NotFound()
+    public async Task Get_PlayerById_Unknown_Returns404NotFound()
     {
         // Arrange
         var id = Guid.NewGuid();
@@ -248,7 +248,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Get_PlayerBySquadNumber_NonExisting_Returns404NotFound()
+    public async Task Get_PlayerBySquadNumber_Unknown_Returns404NotFound()
     {
         // Arrange
         var squadNumber = 999;
@@ -345,7 +345,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Put_PlayerBySquadNumber_NonExisting_Returns404NotFound()
+    public async Task Put_PlayerBySquadNumber_Unknown_Returns404NotFound()
     {
         // Arrange
         var squadNumber = 999;
@@ -461,7 +461,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Delete_PlayerBySquadNumber_NonExisting_Returns404NotFound()
+    public async Task Delete_PlayerBySquadNumber_Unknown_Returns404NotFound()
     {
         // Arrange
         var squadNumber = 999;

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Utilities/PlayerFakes.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Utilities/PlayerFakes.cs
@@ -12,6 +12,14 @@ namespace Dotnet.Samples.AspNetCore.WebApi.Tests.Utilities;
 /// useful when you need behavior that's closer to reality but still want
 /// to avoid external dependencies.
 /// </summary>
+/// <remarks>
+/// Data-state vocabulary used across controller tests:
+/// <list type="bullet">
+///   <item><term>existing</term><description>Player is present in the database.</description></item>
+///   <item><term>nonexistent</term><description>Player is absent, valid shape for creation (POST scenarios).</description></item>
+///   <item><term>unknown</term><description>Valid ID format, absent from database (404-by-lookup scenarios).</description></item>
+/// </list>
+/// </remarks>
 public static class PlayerFakes
 {
     private static string? FormatBirth(DateTime? dateOfBirth) =>


### PR DESCRIPTION
## Summary

- Rename five controller test methods from `NonExisting` to `Nonexistent` to align with the canonical three-term data-state vocabulary shared across the six comparison repos
- Add XML doc `<remarks>` block to `PlayerFakes` documenting the `existing` / `nonexistent` / `unknown` terms

## Test plan

- [ ] All 41 tests pass (`dotnet test --settings .runsettings`)
- [ ] No logic changes — rename only

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test naming to use a consistent three-term vocabulary for data-state scenarios.

* **Documentation**
  * Added shared vocabulary remarks to test utilities describing "existing", "nonexistent", and "unknown" states.

* **Chores**
  * Minor internal standardization and maintenance for naming consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->