### PR TITLE
test(repositories): add integration tests for `Repository<T>` and `PlayerRepository` (#461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Added
 
+- Add `test/.../Integration/PlayerRepositoryTests.cs` with 9 integration tests covering `Repository<T>` (`GetAllAsync`, `FindByIdAsync`, `RemoveAsync`) and `PlayerRepository` (`FindBySquadNumberAsync`, `SquadNumberExistsAsync`); all tests use `DatabaseFakes.MigrateAsync()` on in-memory SQLite and are tagged `[Trait("Category", "Integration")]` (#461)
 - Add `ValidateAsync_SquadNumberNegative_ReturnsValidationError` test to exercise the `GreaterThan(0)` rule with a negative value, which passes `NotEmpty()` but fails the greater-than rule (#427)
 - Add `ValidateAsync_FirstNameEmptyInUpdateRuleSet_ReturnsValidationError` test to verify the `"Update"` rule set enforces structural field validation (#427)
 - Add `adr/` directory with 12 Architecture Decision Records documenting architectural choices, technology decisions, and design trade-offs (#372)

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerRepositoryTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerRepositoryTests.cs
@@ -105,11 +105,16 @@ public class PlayerRepositoryTests : IAsyncLifetime
     [Trait("Category", "Integration")]
     public async Task RemoveAsync_UnknownId_NoExceptionThrown()
     {
+        // Arrange
+        var countBefore = (await _repository.GetAllAsync()).Count;
+
         // Act
         var act = async () => await _repository.RemoveAsync(Guid.NewGuid());
 
         // Assert
         await act.Should().NotThrowAsync();
+        var countAfter = (await _repository.GetAllAsync()).Count;
+        countAfter.Should().Be(countBefore);
     }
 
     /* -------------------------------------------------------------------------
@@ -120,20 +125,27 @@ public class PlayerRepositoryTests : IAsyncLifetime
     [Trait("Category", "Integration")]
     public async Task FindBySquadNumberAsync_ExistingSquadNumber_ReturnsPlayer()
     {
+        // Arrange
+        var expected = PlayerFakes.MakeFromStarting11(23);
+
         // Act
-        var player = await _repository.FindBySquadNumberAsync(23);
+        var player = await _repository.FindBySquadNumberAsync(expected.SquadNumber);
 
         // Assert
         player.Should().NotBeNull();
-        player!.SquadNumber.Should().Be(23);
+        player!.SquadNumber.Should().Be(expected.SquadNumber);
     }
 
     [Fact]
     [Trait("Category", "Integration")]
     public async Task FindBySquadNumberAsync_UnknownSquadNumber_ReturnsNull()
     {
+        // Arrange — derive a squad number guaranteed not to exist in the seeded data
+        var seeded = await _repository.GetAllAsync();
+        var unknownSquadNumber = seeded.Max(p => p.SquadNumber) + 1;
+
         // Act
-        var player = await _repository.FindBySquadNumberAsync(999);
+        var player = await _repository.FindBySquadNumberAsync(unknownSquadNumber);
 
         // Assert
         player.Should().BeNull();
@@ -147,8 +159,11 @@ public class PlayerRepositoryTests : IAsyncLifetime
     [Trait("Category", "Integration")]
     public async Task SquadNumberExistsAsync_ExistingSquadNumber_ReturnsTrue()
     {
+        // Arrange
+        var expected = PlayerFakes.MakeFromStarting11(23);
+
         // Act
-        var exists = await _repository.SquadNumberExistsAsync(23);
+        var exists = await _repository.SquadNumberExistsAsync(expected.SquadNumber);
 
         // Assert
         exists.Should().BeTrue();
@@ -158,8 +173,12 @@ public class PlayerRepositoryTests : IAsyncLifetime
     [Trait("Category", "Integration")]
     public async Task SquadNumberExistsAsync_UnknownSquadNumber_ReturnsFalse()
     {
+        // Arrange — derive a squad number guaranteed not to exist in the seeded data
+        var seeded = await _repository.GetAllAsync();
+        var unknownSquadNumber = seeded.Max(p => p.SquadNumber) + 1;
+
         // Act
-        var exists = await _repository.SquadNumberExistsAsync(999);
+        var exists = await _repository.SquadNumberExistsAsync(unknownSquadNumber);
 
         // Assert
         exists.Should().BeFalse();

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerRepositoryTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerRepositoryTests.cs
@@ -1,0 +1,167 @@
+using System.Data.Common;
+using Dotnet.Samples.AspNetCore.WebApi.Data;
+using Dotnet.Samples.AspNetCore.WebApi.Models;
+using Dotnet.Samples.AspNetCore.WebApi.Repositories;
+using Dotnet.Samples.AspNetCore.WebApi.Tests.Utilities;
+using FluentAssertions;
+
+namespace Dotnet.Samples.AspNetCore.WebApi.Tests.Integration;
+
+/// <summary>
+/// Integration tests for <see cref="Repository{T}"/> and <see cref="PlayerRepository"/>.
+/// Each test runs against an in-memory SQLite database with the full EF Core migration
+/// chain applied via <see cref="DatabaseFakes.MigrateAsync"/>, which also validates
+/// that the migration chain itself is healthy as a side effect.
+/// </summary>
+public class PlayerRepositoryTests : IAsyncLifetime
+{
+    private DbConnection _connection = default!;
+    private PlayerDbContext _dbContext = default!;
+    private PlayerRepository _repository = default!;
+
+    public async Task InitializeAsync()
+    {
+        var (connection, options) = DatabaseFakes.CreateSqliteConnection();
+        _connection = connection;
+        _dbContext = DatabaseFakes.CreateDbContext(options);
+        await _dbContext.MigrateAsync();
+        _repository = new PlayerRepository(_dbContext);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    /* -------------------------------------------------------------------------
+     * GetAllAsync
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task GetAllAsync_WhenCalled_ReturnsAllSeededPlayers()
+    {
+        // Act
+        var players = await _repository.GetAllAsync();
+
+        // Assert
+        players.Should().HaveCount(26);
+        _dbContext.ChangeTracker.Entries<Player>().Should().BeEmpty();
+    }
+
+    /* -------------------------------------------------------------------------
+     * FindByIdAsync
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FindByIdAsync_ExistingId_ReturnsPlayer()
+    {
+        // Arrange — resolve a real ID from the seeded database
+        var seeded = await _repository.GetAllAsync();
+        var existingId = seeded[0].Id;
+
+        // Act
+        var player = await _repository.FindByIdAsync(existingId);
+
+        // Assert
+        player.Should().NotBeNull();
+        player!.Id.Should().Be(existingId);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FindByIdAsync_UnknownId_ReturnsNull()
+    {
+        // Act
+        var player = await _repository.FindByIdAsync(Guid.NewGuid());
+
+        // Assert
+        player.Should().BeNull();
+    }
+
+    /* -------------------------------------------------------------------------
+     * RemoveAsync
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RemoveAsync_ExistingEntity_RemovesFromDatabase()
+    {
+        // Arrange
+        var seeded = await _repository.GetAllAsync();
+        var existingId = seeded[0].Id;
+
+        // Act
+        await _repository.RemoveAsync(existingId);
+
+        // Assert
+        var player = await _repository.FindByIdAsync(existingId);
+        player.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task RemoveAsync_UnknownId_NoExceptionThrown()
+    {
+        // Act
+        var act = async () => await _repository.RemoveAsync(Guid.NewGuid());
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    /* -------------------------------------------------------------------------
+     * FindBySquadNumberAsync
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FindBySquadNumberAsync_ExistingSquadNumber_ReturnsPlayer()
+    {
+        // Act
+        var player = await _repository.FindBySquadNumberAsync(23);
+
+        // Assert
+        player.Should().NotBeNull();
+        player!.SquadNumber.Should().Be(23);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FindBySquadNumberAsync_UnknownSquadNumber_ReturnsNull()
+    {
+        // Act
+        var player = await _repository.FindBySquadNumberAsync(999);
+
+        // Assert
+        player.Should().BeNull();
+    }
+
+    /* -------------------------------------------------------------------------
+     * SquadNumberExistsAsync
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task SquadNumberExistsAsync_ExistingSquadNumber_ReturnsTrue()
+    {
+        // Act
+        var exists = await _repository.SquadNumberExistsAsync(23);
+
+        // Assert
+        exists.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task SquadNumberExistsAsync_UnknownSquadNumber_ReturnsFalse()
+    {
+        // Act
+        var exists = await _repository.SquadNumberExistsAsync(999);
+
+        // Assert
+        exists.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- Add `test/.../Integration/PlayerRepositoryTests.cs` with 9 integration tests covering the non-trivial behaviors of `Repository<T>` and `PlayerRepository`
- All tests run against in-memory SQLite via `DatabaseFakes.MigrateAsync()`, validating the full EF Core migration chain as a side effect
- Tests are tagged `[Trait("Category", "Integration")]` to distinguish from unit tests
- Both branches of `RemoveAsync` (entity found / not found) and `SquadNumberExistsAsync` (exists / does not exist) are exercised

## Test coverage

| Method | Scenario |
|--------|----------|
| `GetAllAsync` | Returns all 26 seeded players; verifies `AsNoTracking()` via empty ChangeTracker |
| `FindByIdAsync` | Existing ID returns player; unknown ID returns `null` |
| `RemoveAsync` | Existing entity is removed; unknown ID is a no-op with no exception |
| `FindBySquadNumberAsync` | Existing squad number returns player; unknown returns `null` |
| `SquadNumberExistsAsync` | Existing squad number returns `true`; unknown returns `false` |

## Test plan

- [x] `dotnet build --configuration Release` passes with 0 warnings
- [x] `dotnet test --settings .runsettings` passes — 50/50 tests (9 new)
- [x] `dotnet csharpier --check .` passes

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced comprehensive integration test suite with 9 tests for player repository functionality, including validation of player retrieval, database removal operations, and squad number lookups. Tests execute against a SQLite database to ensure robust data handling and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->