### PR TITLE
test(integration): add `WebApplicationFactory` HTTP tests (#421)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,14 +58,15 @@ test/Dotnet.Samples.AspNetCore.WebApi.Tests/
 
 ### Test naming conventions
 
-Tests live under `test/.../Unit/`. Two naming patterns, strictly by layer:
+Two naming patterns, strictly by layer:
 
-| Layer                | Pattern                                                       | Example                                                          |
-|----------------------|---------------------------------------------------------------|------------------------------------------------------------------|
-| Controller           | `{HttpMethod}_{Resource}_{Condition}_Returns{Outcome}`        | `Get_Players_Existing_ReturnsPlayers`                            |
-| Service / Validator  | `{MethodName}_{StateUnderTest}_{ExpectedBehavior}`            | `RetrieveAsync_CacheMiss_QueriesRepositoryAndCachesResult`       |
+| Layer                | Location              | Pattern                                                       | Example                                                          |
+|----------------------|-----------------------|---------------------------------------------------------------|------------------------------------------------------------------|
+| Controller (unit)    | `test/.../Unit/`      | `{HttpMethod}_{Resource}_{Condition}_Returns{Outcome}`        | `Get_Players_Existing_ReturnsPlayers`                            |
+| Service / Validator  | `test/.../Unit/`      | `{MethodName}_{StateUnderTest}_{ExpectedBehavior}`            | `RetrieveAsync_CacheMiss_QueriesRepositoryAndCachesResult`       |
+| HTTP integration     | `test/.../Integration/` | `{HttpMethod}_{Resource}_{Condition}_Returns{Outcome}`      | `Get_Players_Existing_Returns200Ok`                              |
 
-Each pattern has exactly three underscore-delimited segments. Do not add a fourth segment.
+Each pattern has exactly three underscore-delimited segments where `{HttpMethod}_{Resource}` counts as the first segment. Do not add a fourth segment.
 
 ### FluentValidation rule sets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Added
 
+- Add `adr/0013-testing-strategy.md` documenting the decision to implement the full test pyramid as a deliberate educational choice (#421)
+- Add `test/.../Integration/PlayerWebApplicationTests.cs` with 14 HTTP-layer integration tests covering all player endpoints and `/health` via `WebApplicationFactory<Program>` backed by in-memory SQLite; includes `Utilities/TestAuthHandler.cs` to bypass `[Authorize]` on `GET /players/{id:Guid}`; expose `Program` to the test project via `public partial class Program {}` in `Program.cs`; add `Microsoft.AspNetCore.Mvc.Testing` to the test project (#421)
 - Add `test/.../Integration/PlayerRepositoryTests.cs` with 9 integration tests covering `Repository<T>` (`GetAllAsync`, `FindByIdAsync`, `RemoveAsync`) and `PlayerRepository` (`FindBySquadNumberAsync`, `SquadNumberExistsAsync`); all tests use `DatabaseFakes.MigrateAsync()` on in-memory SQLite and are tagged `[Trait("Category", "Integration")]` (#461)
 - Add `ValidateAsync_SquadNumberNegative_ReturnsValidationError` test to exercise the `GreaterThan(0)` rule with a negative value, which passes `NotEmpty()` but fails the greater-than rule (#427)
 - Add `ValidateAsync_FirstNameEmptyInUpdateRuleSet_ReturnsValidationError` test to verify the `"Update"` rule set enforces structural field validation (#427)

--- a/adr/0013-testing-strategy.md
+++ b/adr/0013-testing-strategy.md
@@ -1,0 +1,49 @@
+# 0013. Testing Strategy
+
+Date: 2026-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+The project is a learning reference for a REST API built with ASP.NET Core. Its primary goal is educational clarity — it must be immediately understandable to developers studying the stack, not just functional in production.
+
+For a CRUD API of this size, a single suite of HTTP-layer integration tests (using `WebApplicationFactory<Program>` backed by an in-memory SQLite database) would cover the majority of meaningful risk. Such tests exercise the full request pipeline — routing, middleware, validation, serialization, and database interaction — with minimal setup.
+
+The question was whether to stop there or to also add unit tests for each layer (controller, service, validator, repository) separately.
+
+## Decision
+
+The project implements the full test pyramid:
+
+- **Unit tests** for each layer in isolation (controller, service, validator, repository), with dependencies replaced by Moq mocks or in-memory fakes.
+- **Repository integration tests** that run EF Core queries against in-memory SQLite via the full migration chain, validating query correctness and migration health as a side effect.
+- **HTTP integration tests** (`PlayerWebApplicationTests`) that send real HTTP requests through `WebApplicationFactory<Program>`, exercising the entire pipeline end-to-end.
+
+Some overlap between layers is accepted deliberately.
+
+## Rationale
+
+The redundancy is the point. Having all test types in one place allows a reader to see exactly what each layer tests, what it isolates, and what it leaves to the layer above or below. The test suite is as much documentation as it is a safety net.
+
+The repository integration tests in particular serve two purposes beyond what the HTTP tests provide: they validate individual EF Core queries in isolation (making failures easier to diagnose) and they run `MigrateAsync()` as a side effect, which acts as a canary for migration chain health.
+
+## Consequences
+
+### Positive
+
+- Every layer of the architecture has dedicated tests, making failure diagnosis straightforward.
+- The test suite demonstrates the full range of testing patterns available in the .NET ecosystem.
+- Migration health is continuously validated as a side effect of the repository tests.
+
+### Negative
+
+- Test count is higher than strictly necessary for confidence.
+- Maintenance cost is proportionally higher — changes to shared fixtures or fakes may require updates across multiple test classes.
+
+### Neutral
+
+- The HTTP integration tests (`PlayerWebApplicationTests`) are the minimum viable test suite. All other test classes add depth, not breadth.
+- The `409 Conflict` branch on `POST /players` is unreachable via the HTTP pipeline: the `BeUniqueSquadNumber` rule in the `"Create"` validation rule set catches duplicates first and returns `400`. This path is covered by the controller unit test, where validation is mocked to pass.

--- a/adr/README.md
+++ b/adr/README.md
@@ -18,6 +18,7 @@ This directory contains Architecture Decision Records (ADRs) for this project. A
 | [0010](0010-use-serilog-for-structured-logging.md) | Use Serilog for Structured Logging | Accepted |
 | [0011](0011-use-docker-for-containerization.md) | Use Docker for Containerization | Accepted |
 | [0012](0012-use-stadium-themed-semantic-versioning.md) | Use Stadium-Themed Semantic Versioning | Accepted |
+| [0013](0013-testing-strategy.md) | Testing Strategy | Accepted |
 
 ## When to Create an ADR
 

--- a/src/Dotnet.Samples.AspNetCore.WebApi/Program.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Program.cs
@@ -122,3 +122,8 @@ if (app.Environment.IsDevelopment())
 app.MapControllers();
 
 await app.RunAsync();
+
+public partial class Program
+{
+    protected Program() { }
+}

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Dotnet.Samples.AspNetCore.WebApi.Tests.csproj
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Dotnet.Samples.AspNetCore.WebApi.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test dependencies">
+  <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" PrivateAssets="all" />
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" PrivateAssets="all" />
   <PackageReference Include="Moq" Version="4.20.72" PrivateAssets="all" />
   <PackageReference Include="FluentAssertions" Version="8.9.0" PrivateAssets="all" />

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
@@ -1,0 +1,339 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using Dotnet.Samples.AspNetCore.WebApi.Data;
+using Dotnet.Samples.AspNetCore.WebApi.Models;
+using Dotnet.Samples.AspNetCore.WebApi.Tests.Utilities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dotnet.Samples.AspNetCore.WebApi.Tests.Integration;
+
+/// <summary>
+/// Integration tests for the player endpoints exposed by the web application.
+/// Each test exercises the full ASP.NET Core request pipeline — routing,
+/// middleware, validation, serialization — via <see cref="WebApplicationFactory{TEntryPoint}"/>
+/// backed by an in-memory SQLite database. The factory is created fresh per test
+/// (via <see cref="IAsyncLifetime"/>) to ensure state isolation.
+/// </summary>
+public class PlayerWebApplicationTests : IAsyncLifetime
+{
+    private WebApplicationFactory<Program> _factory = default!;
+    private WebApplicationFactory<Program> _authorizedFactory = default!;
+    private HttpClient _client = default!;
+    private HttpClient _authorizedClient = default!;
+    private DbConnection _connection = default!;
+
+    public Task InitializeAsync()
+    {
+        var (connection, _) = DatabaseFakes.CreateSqliteConnection();
+        _connection = connection;
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                // AddDbContextPool registers three service types. All three must be
+                // removed before re-registering with AddDbContext; leaving any one
+                // causes startup to fail when the pool tries to resolve its options.
+                var descriptors = services
+                    .Where(d =>
+                        d.ServiceType == typeof(DbContextOptions<PlayerDbContext>)
+                        || d.ServiceType == typeof(PlayerDbContext)
+                        || (
+                            d.ServiceType.IsGenericType
+                            && d.ServiceType.GetGenericArguments().Length > 0
+                            && d.ServiceType.GetGenericArguments()[0] == typeof(PlayerDbContext)
+                        )
+                    )
+                    .ToList();
+
+                foreach (var descriptor in descriptors)
+                    services.Remove(descriptor);
+
+                services.AddDbContext<PlayerDbContext>(options => options.UseSqlite(_connection));
+            });
+        });
+
+        _client = _factory.CreateClient();
+
+        // Derived factory that layers authentication on top of the base factory.
+        // Used only by tests targeting endpoints protected with [Authorize].
+        // Keeping auth out of the base factory means unauthenticated tests will
+        // fail if an endpoint accidentally becomes protected.
+        _authorizedFactory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureTestServices(services =>
+                services
+                    .AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName,
+                        _ => { }
+                    )
+            )
+        );
+
+        _authorizedClient = _authorizedFactory.CreateClient();
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _authorizedClient.Dispose();
+        _client.Dispose();
+        await _authorizedFactory.DisposeAsync();
+        await _factory.DisposeAsync();
+        await _connection.DisposeAsync();
+    }
+
+    /* -------------------------------------------------------------------------
+     * GET /players
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_Players_Existing_Returns200Ok()
+    {
+        // Act
+        var response = await _client.GetAsync("/players");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var players = await response.Content.ReadFromJsonAsync<List<PlayerResponseModel>>();
+        players.Should().HaveCount(26);
+    }
+
+    /* -------------------------------------------------------------------------
+     * GET /players/{id:Guid}
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_PlayerById_Existing_Returns200Ok()
+    {
+        // Arrange — resolve a real ID from the seeded database
+        await using var scope = _authorizedFactory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<PlayerDbContext>();
+        var existingId = (await db.Players.FirstAsync()).Id;
+
+        // Act
+        var response = await _authorizedClient.GetAsync($"/players/{existingId}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var player = await response.Content.ReadFromJsonAsync<PlayerResponseModel>();
+        player.Should().NotBeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_PlayerById_Unknown_Returns404NotFound()
+    {
+        // Act
+        var response = await _authorizedClient.GetAsync($"/players/{Guid.NewGuid()}");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Title.Should().Be("Not Found");
+    }
+
+    /* -------------------------------------------------------------------------
+     * GET /players/squadNumber/{squadNumber:int}
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_PlayerBySquadNumber_Existing_Returns200Ok()
+    {
+        // Act
+        var response = await _client.GetAsync("/players/squadNumber/23");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var player = await response.Content.ReadFromJsonAsync<PlayerResponseModel>();
+        player.Should().NotBeNull();
+        player!.Dorsal.Should().Be(23);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_PlayerBySquadNumber_Unknown_Returns404NotFound()
+    {
+        // Act
+        var response = await _client.GetAsync("/players/squadNumber/999");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Title.Should().Be("Not Found");
+    }
+
+    /* -------------------------------------------------------------------------
+     * POST /players
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Post_Players_Nonexistent_Returns201Created()
+    {
+        // Arrange — squad number 27 (Lo Celso) is not in the seeded data
+        var request = PlayerFakes.MakeRequestModelForCreate();
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/players", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var player = await response.Content.ReadFromJsonAsync<PlayerResponseModel>();
+        player.Should().NotBeNull();
+        player!.Dorsal.Should().Be(request.SquadNumber);
+    }
+
+    // Note: the controller's 409 Conflict branch (squad number already exists) is
+    // unreachable via the HTTP pipeline. The "Create" validation rule set includes
+    // BeUniqueSquadNumber, which returns a 400 validation error before the
+    // controller's own duplicate check ever runs. The 409 path is covered by the
+    // unit test Post_Players_Existing_Returns409Conflict, where validation is mocked
+    // to pass so the controller logic can be exercised in isolation.
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Post_Players_ValidationError_Returns400BadRequest()
+    {
+        // Arrange — SquadNumber 0 is the int default, fails NotEmpty
+        var request = PlayerFakes.MakeRequestModelForCreate();
+        request.SquadNumber = 0;
+
+        // Act
+        var response = await _client.PostAsJsonAsync("/players", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    /* -------------------------------------------------------------------------
+     * PUT /players/squadNumber/{squadNumber:int}
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Put_PlayerBySquadNumber_Existing_Returns204NoContent()
+    {
+        // Arrange
+        var request = PlayerFakes.MakeRequestModelForUpdate(23);
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/players/squadNumber/23", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Put_PlayerBySquadNumber_Unknown_Returns404NotFound()
+    {
+        // Arrange — squad number 999 does not exist; body matches route to avoid mismatch error
+        var request = PlayerFakes.MakeRequestModelForUpdate(23);
+        request.SquadNumber = 999;
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/players/squadNumber/999", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Title.Should().Be("Not Found");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Put_PlayerBySquadNumber_ValidationError_Returns400BadRequest()
+    {
+        // Arrange — SquadNumber -1 fails GreaterThan(0)
+        var request = PlayerFakes.MakeRequestModelForUpdate(23);
+        request.SquadNumber = -1;
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/players/squadNumber/23", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Put_PlayerBySquadNumber_SquadNumberMismatch_Returns400BadRequest()
+    {
+        // Arrange — body squad number (99) differs from route (23); both are valid values
+        // so validation passes and the mismatch guard in the controller fires instead
+        var request = PlayerFakes.MakeRequestModelForUpdate(23);
+        request.SquadNumber = 99;
+
+        // Act
+        var response = await _client.PutAsJsonAsync("/players/squadNumber/23", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem.Title.Should().Be("Bad Request");
+    }
+
+    /* -------------------------------------------------------------------------
+     * DELETE /players/squadNumber/{squadNumber:int}
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Delete_PlayerBySquadNumber_Existing_Returns204NoContent()
+    {
+        // Act
+        var response = await _client.DeleteAsync("/players/squadNumber/23");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Delete_PlayerBySquadNumber_Unknown_Returns404NotFound()
+    {
+        // Act
+        var response = await _client.DeleteAsync("/players/squadNumber/999");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        problem!.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Title.Should().Be("Not Found");
+    }
+
+    /* -------------------------------------------------------------------------
+     * GET /health
+     * ---------------------------------------------------------------------- */
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task Get_Health_Healthy_Returns200Ok()
+    {
+        // Act
+        var response = await _client.GetAsync("/health");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Utilities/TestAuthHandler.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Utilities/TestAuthHandler.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Dotnet.Samples.AspNetCore.WebApi.Tests.Utilities;
+
+/// <summary>
+/// A test authentication handler that automatically authenticates every request,
+/// bypassing the real authentication scheme. Used in integration tests to exercise
+/// endpoints protected with [Authorize] without requiring a real token.
+/// </summary>
+internal sealed class TestAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder
+) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "Test";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[] { new Claim(ClaimTypes.Name, "TestUser") };
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/packages.lock.json
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "8.9.0",
         "contentHash": "Y5RDjxaVlxWX2yy0X/ay1tJjSKMOtjepSb83mmfngFS63hm3LsoZNj6nhmImzm1ifRmpF9ouvmHjx9nNwnkpDg=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "Gdtv34h2qvynOEu+B2+6apBiiPhEs39namGax02UgaQMRetlxQ88p2/jK1eIdz3m1NRgYszNBN/jBdXkucZhvw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.4.0, )",
@@ -89,6 +100,11 @@
         "dependencies": {
           "Microsoft.OpenApi": "2.0.0"
         }
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "Q3ia+k+wYM3Iv/Qq5IETOdpz/R0xizs3WNAXz699vEQx5TMVAfG715fBSq9Thzopvx8dYZkxQ/mumTn6AJ/vGQ=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -214,6 +230,58 @@
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -232,6 +300,16 @@
         "resolved": "10.0.5",
         "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
       },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -247,6 +325,50 @@
         "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
         "dependencies": {
           "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
@@ -279,6 +401,67 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -286,6 +469,18 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
           "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -490,8 +685,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
       "xunit.abstractions": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

- Adds `PlayerWebApplicationTests` — 14 HTTP-layer integration tests covering all player endpoints and `/health` via `WebApplicationFactory<Program>` backed by in-memory SQLite
- Adds `TestAuthHandler` utility to bypass `[Authorize]` on `GET /players/{id:Guid}` in tests
- Exposes `Program` to the test project via `public partial class Program {}` in `Program.cs`
- Adds `Microsoft.AspNetCore.Mvc.Testing` to the test project
- Adds ADR 0013 documenting the full test pyramid as a deliberate educational choice

## Test plan

- [x] `dotnet build --configuration Release` passes
- [x] `dotnet test --settings .runsettings` — 64 tests, 0 failures
- [x] `dotnet csharpier --check .` passes

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suite with 14 tests covering all player endpoints and health checks, verifying request handling and response formats end-to-end

* **Documentation**
  * Added Architecture Decision Record documenting the adopted test-pyramid strategy for the project

* **Chores**
  * Updated test infrastructure to support integration testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->