### PR TITLE
ci(cd): normalize and align CD pipeline (#465)

### DIFF
--- a/.github/workflows/dotnet-cd.yml
+++ b/.github/workflows/dotnet-cd.yml
@@ -13,11 +13,40 @@ env:
   PACKAGE_NAME: nanotaboada/dotnet-samples-aspnetcore-webapi
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up .NET ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v5.2.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+          cache: true
+          cache-dependency-path: |
+            src/Dotnet.Samples.AspNetCore.WebApi/packages.lock.json
+            test/Dotnet.Samples.AspNetCore.WebApi.Tests/packages.lock.json
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build projects (Release configuration)
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test --configuration Release --no-build --verbosity normal
+
   release:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -77,24 +106,6 @@ jobs:
           echo "📦 Release version: $SEMVER"
           echo "🏟️ Stadium name: $STADIUM"
 
-      - name: Set up .NET ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v5.2.0
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-          cache: true
-          cache-dependency-path: |
-            src/Dotnet.Samples.AspNetCore.WebApi/packages.lock.json
-            test/Dotnet.Samples.AspNetCore.WebApi.Tests/packages.lock.json
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build projects (Release configuration)
-        run: dotnet build --configuration Release --no-restore
-
-      - name: Run tests
-        run: dotnet test --configuration Release --no-build --verbosity normal
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4.1.0
         with:
@@ -106,18 +117,26 @@ jobs:
         uses: docker/setup-buildx-action@v4.0.0
 
       - name: Build and push Docker image to GitHub Container Registry
+        id: push
         uses: docker/build-push-action@v7.0.0
         with:
           context: .
           push: true
-          platforms: linux/amd64
-          provenance: false
+          platforms: linux/amd64,linux/arm64
+          provenance: mode=max
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
             ghcr.io/${{ env.PACKAGE_NAME }}:latest
             ghcr.io/${{ env.PACKAGE_NAME }}:${{ steps.version.outputs.semver }}
             ghcr.io/${{ env.PACKAGE_NAME }}:${{ steps.version.outputs.stadium }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-name: ghcr.io/${{ env.PACKAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
       - name: Generate changelog
         id: changelog
@@ -127,15 +146,15 @@ jobs:
 
           if [ -z "$PREVIOUS_TAG" ]; then
             echo "📝 First release - no previous tag found"
-            CHANGELOG="Initial release"
+            CHANGELOG="No changes (first release)"
           else
             echo "📝 Generating changelog from $PREVIOUS_TAG to ${{ steps.version.outputs.tag_name }}"
-            CHANGELOG=$(git log --pretty=format:"- %s (%h)" ${PREVIOUS_TAG}..${{ steps.version.outputs.tag_name }})
-          fi
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges ${PREVIOUS_TAG}..${{ steps.version.outputs.tag_name }})
 
-          # Write changelog to file
-          echo "$CHANGELOG" > changelog.txt
-          cat changelog.txt
+            if [ -z "$CHANGELOG" ]; then
+              CHANGELOG="No new changes since $PREVIOUS_TAG"
+            fi
+          fi
 
           # Set output for use in release body
           {
@@ -166,6 +185,10 @@ jobs:
             # Latest
             docker pull ghcr.io/${{ env.PACKAGE_NAME }}:latest
             ```
+
+            ## Changes
+
+            ${{ steps.changelog.outputs.changelog }}
 
             ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Added
 
+- Extract `test` job from `release` in CD pipeline so tests run in isolation
+  before any publish step; add `linux/arm64` to build platforms; add
+  `id-token: write` and `attestations: write` permissions to `release`; set
+  `provenance: mode=max` and attest the image digest with
+  `actions/attest-build-provenance@v4.1.0` (`push-to-registry: true`); add
+  `--no-merges` to the changelog `git log` command; add empty changelog guard;
+  normalize first-release message to `"No changes (first release)"` (#465)
+
 - Add `adr/0013-testing-strategy.md` documenting the decision to implement the full test pyramid as a deliberate educational choice (#421)
 - Add `test/.../Integration/PlayerWebApplicationTests.cs` with 14 HTTP-layer integration tests covering all player endpoints and `/health` via `WebApplicationFactory<Program>` backed by in-memory SQLite; includes `Utilities/TestAuthHandler.cs` to bypass `[Authorize]` on `GET /players/{id:Guid}`; expose `Program` to the test project via `public partial class Program {}` in `Program.cs`; add `Microsoft.AspNetCore.Mvc.Testing` to the test project (#421)
 - Add `test/.../Integration/PlayerRepositoryTests.cs` with 9 integration tests covering `Repository<T>` (`GetAllAsync`, `FindByIdAsync`, `RemoveAsync`) and `PlayerRepository` (`FindBySquadNumberAsync`, `SquadNumberExistsAsync`); all tests use `DatabaseFakes.MigrateAsync()` on in-memory SQLite and are tagged `[Trait("Category", "Integration")]` (#461)


### PR DESCRIPTION
## Summary

- Extract `test` job from `release` so tests run in isolation before any publish step
- Add `linux/arm64` to build platforms
- Add `id-token: write` and `attestations: write` permissions to `release`
- Set `provenance: mode=max`; attest image digest with `actions/attest-build-provenance@v4.1.0`
- Add `--no-merges` to the changelog `git log` command
- Add empty changelog guard (`"No new changes since $PREVIOUS_TAG"`)
- Normalize first-release message to `"No changes (first release)"`
- Remove `changelog.txt` write step
- Add `## Changes` section to release body

## Test plan

- [ ] CI passes on this branch
- [ ] `test` job runs and fails fast if tests fail (before Docker build starts)
- [ ] `release` job only runs when `test` succeeds
- [ ] Verify attestation step on next tagged release

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended platform support to build for ARM64 architecture in addition to AMD64.
  * Added build provenance attestations to enable security verification of published releases.
  * Refactored testing workflow to run as a dedicated step prior to release steps.
  * Improved changelog generation with better handling of first releases and empty updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->