### PR TITLE
docs(changelog): prepare release notes for v2.1.1-ekaterinburg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+---
+
+## [2.1.1 - ekaterinburg] - 2026-04-12
+
+### Added
+
 - Extract `test` job from `release` in CD pipeline so tests run in isolation
   before any publish step; add `linux/arm64` to build platforms; add
   `id-token: write` and `attestations: write` permissions to `release`; set
@@ -250,7 +262,8 @@ The CD workflow automatically:
 
 ---
 
-[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.0-dusseldorf...HEAD
+[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.1-ekaterinburg...HEAD
+[2.1.1 - ekaterinburg]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.0-dusseldorf...v2.1.1-ekaterinburg
 [2.1.0 - dusseldorf]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.0.0-centenario...v2.1.0-dusseldorf
 [2.0.0 - centenario]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v1.1.0-bernabeu...v2.0.0-centenario
 [1.1.0 - bernabeu]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v1.0.0-azteca...v1.1.0-bernabeu


### PR DESCRIPTION
## Summary

- Promotes all `[Unreleased]` entries to `## [2.1.1 - Ekaterinburg Arena] - 2026-04-12`
- Adds a fresh empty `## [Unreleased]` section for future work
- Updates compare links: `[unreleased]` now points to `v2.1.1-ekaterinburg...HEAD`; adds `[2.1.1 - ekaterinburg]` link

## What's in this release

**Added:** CD pipeline improvements (test job isolation, `linux/arm64`, image attestation), ADR 0013 (testing strategy), repository and web application integration tests, additional validator tests, and 12 ADRs documenting architectural decisions.

**Changed:** Rate limiting exemption for `/health`, middleware pipeline ordering, EF Core `MigrateAsync()` at startup replacing pre-seeded DB, Alpine runtime image (113 MB → 74 MB), test naming conventions normalized, CD workflow tag reachability check.

**Fixed:** `GET /players` returns `200 OK` with empty list instead of `404`; AutoMapper profile explicitly ignores `Id` source member.

## Test plan

- [x] `dotnet build --configuration Release` — passed
- [x] `dotnet test --settings .runsettings` — 64/64 passed
- [x] `dotnet csharpier --check .` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new 2.1.1 release entry with an "Added" subsection and populated release notes.
  * Inserted empty "Changed", "Fixed", and "Removed" subsections under Unreleased for future entries.
  * Updated changelog comparison links to include the new 2.1.1 release.

* **Chores**
  * Adjusted changelog structure and links to reflect the 2.1.1 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->