### PR TITLE
feat(api): adopt 422 Unprocessable Entity for validation errors (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Changed
 
+- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is now reserved for malformed requests (unparseable JSON, wrong `Content-Type`, route/body mismatch) per RFC 9457
+
 ### Fixed
 
 ### Removed

--- a/src/Dotnet.Samples.AspNetCore.WebApi/Controllers/PlayerController.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Controllers/PlayerController.cs
@@ -27,13 +27,13 @@ public class PlayerController(
     /// </summary>
     /// <param name="player">The PlayerRequestModel</param>
     /// <response code="201">Created</response>
-    /// <response code="400">Bad Request</response>
     /// <response code="409">Conflict</response>
+    /// <response code="422">Unprocessable Entity</response>
     [HttpPost(Name = "Create")]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType<PlayerResponseModel>(StatusCodes.Status201Created)]
-    [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status409Conflict)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status422UnprocessableEntity)]
     public async Task<IResult> PostAsync([FromBody] PlayerRequestModel player)
     {
         // Use the "Create" rule set, which includes BeUniqueSquadNumber.
@@ -49,10 +49,13 @@ public class PlayerController(
                 .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).ToArray());
 
             logger.LogWarning("POST /players validation failed: {@Errors}", errors);
-            return TypedResults.ValidationProblem(
-                errors,
-                detail: "See the errors field for details.",
-                instance: HttpContext?.Request?.Path.ToString()
+            return TypedResults.Problem(
+                new HttpValidationProblemDetails(errors)
+                {
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Detail = "See the errors field for details.",
+                    Instance = HttpContext?.Request?.Path.ToString(),
+                }
             );
         }
 
@@ -177,13 +180,15 @@ public class PlayerController(
     /// <param name="player">The PlayerRequestModel</param>
     /// <param name="squadNumber">The Squad Number of the Player</param>
     /// <response code="204">No Content</response>
-    /// <response code="400">Bad Request</response>
+    /// <response code="400">Bad Request (route/body squad number mismatch)</response>
     /// <response code="404">Not Found</response>
+    /// <response code="422">Unprocessable Entity (field validation failure)</response>
     [HttpPut("squadNumber/{squadNumber:int}", Name = "Update")]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<ProblemDetails>(StatusCodes.Status404NotFound)]
+    [ProducesResponseType<ProblemDetails>(StatusCodes.Status422UnprocessableEntity)]
     public async Task<IResult> PutAsync(
         [FromRoute] int squadNumber,
         [FromBody] PlayerRequestModel player
@@ -207,10 +212,13 @@ public class PlayerController(
                 squadNumber,
                 errors
             );
-            return TypedResults.ValidationProblem(
-                errors,
-                detail: "See the errors field for details.",
-                instance: HttpContext?.Request?.Path.ToString()
+            return TypedResults.Problem(
+                new HttpValidationProblemDetails(errors)
+                {
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Detail = "See the errors field for details.",
+                    Instance = HttpContext?.Request?.Path.ToString(),
+                }
             );
         }
         if (player.SquadNumber != squadNumber)

--- a/src/Dotnet.Samples.AspNetCore.WebApi/Middlewares/ExceptionMiddleware.cs
+++ b/src/Dotnet.Samples.AspNetCore.WebApi/Middlewares/ExceptionMiddleware.cs
@@ -88,7 +88,7 @@ public class ExceptionMiddleware(
     {
         return exception switch
         {
-            ValidationException => (StatusCodes.Status400BadRequest, "Validation Error"),
+            ValidationException => (StatusCodes.Status422UnprocessableEntity, "Validation Error"),
             ArgumentException
             or ArgumentNullException
                 => (StatusCodes.Status400BadRequest, "Bad Request"),

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
@@ -206,7 +206,7 @@ public class PlayerWebApplicationTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Post_Players_ValidationError_Returns400BadRequest()
+    public async Task Post_Players_ValidationError_Returns422UnprocessableEntity()
     {
         // Arrange — SquadNumber 0 is the int default, fails NotEmpty
         var request = PlayerFakes.MakeRequestModelForCreate();
@@ -216,9 +216,9 @@ public class PlayerWebApplicationTests : IAsyncLifetime
         var response = await _client.PostAsJsonAsync("/players", request);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem!.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
     /* -------------------------------------------------------------------------
@@ -259,7 +259,7 @@ public class PlayerWebApplicationTests : IAsyncLifetime
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Put_PlayerBySquadNumber_ValidationError_Returns400BadRequest()
+    public async Task Put_PlayerBySquadNumber_ValidationError_Returns422UnprocessableEntity()
     {
         // Arrange — SquadNumber -1 fails GreaterThan(0)
         var request = PlayerFakes.MakeRequestModelForUpdate(23);
@@ -269,9 +269,9 @@ public class PlayerWebApplicationTests : IAsyncLifetime
         var response = await _client.PutAsJsonAsync("/players/squadNumber/23", request);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         var problem = await response.Content.ReadFromJsonAsync<ProblemDetails>();
-        problem!.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem!.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
     [Fact]

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
@@ -26,7 +26,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Post_Players_ValidationError_Returns400BadRequest()
+    public async Task Post_Players_ValidationError_Returns422UnprocessableEntity()
     {
         // Arrange
         var request = PlayerFakes.MakeRequestModelForCreate();
@@ -63,8 +63,8 @@ public class PlayerControllerTests : IDisposable
                 ),
             Times.Once
         );
-        var httpResult = result.Should().BeOfType<ValidationProblem>().Subject;
-        httpResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        var httpResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        httpResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
     [Fact]
@@ -299,7 +299,7 @@ public class PlayerControllerTests : IDisposable
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Put_PlayerBySquadNumber_ValidationError_Returns400BadRequest()
+    public async Task Put_PlayerBySquadNumber_ValidationError_Returns422UnprocessableEntity()
     {
         // Arrange
         var squadNumber = 20;
@@ -339,8 +339,8 @@ public class PlayerControllerTests : IDisposable
                 ),
             Times.Once
         );
-        var httpResult = result.Should().BeOfType<ValidationProblem>().Subject;
-        httpResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        var httpResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
+        httpResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Field validation failures now return `422 Unprocessable Entity` instead of `400 Bad Request`, correctly distinguishing syntactically valid but semantically invalid requests from malformed ones
- `400 Bad Request` is now reserved for genuinely malformed requests (unparseable JSON, wrong `Content-Type`, route/body squad number mismatch in `PUT`)
- `ExceptionMiddleware` updated to return 422 for uncaught `ValidationException` as a safety net
- Swagger/OpenAPI attributes and XML doc comments updated accordingly
- All unit and integration tests updated to assert the new status code

## Test plan

- [x] `Post_Players_ValidationError_Returns422UnprocessableEntity` — unit + integration
- [x] `Put_PlayerBySquadNumber_ValidationError_Returns422UnprocessableEntity` — unit + integration
- [x] `Put_PlayerBySquadNumber_SquadNumberMismatch_Returns400BadRequest` — unchanged, still 400
- [x] All 64 tests pass

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * API validation failures now return HTTP 422 Unprocessable Entity (RFC 4918) instead of 400 Bad Request for improved HTTP semantics
  * HTTP 400 Bad Request is now reserved for malformed requests (unparseable JSON, incorrect Content-Type, route/body mismatch)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->