### PR TITLE
test(api): add payload assertions to 422 validation error tests (#469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Changed
 
-- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is now reserved for malformed requests (unparseable JSON, wrong `Content-Type`, route/body mismatch) per RFC 9457
+- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is now reserved for malformed requests (unparseable JSON, route/body mismatch); unsupported media types return `415 Unsupported Media Type` (RFC 9110 §15.5.16) via the `[Consumes]` attribute. Error responses follow the Problem Details format (RFC 9457).
 
 ### Fixed
 

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Integration/PlayerWebApplicationTests.cs
@@ -199,10 +199,10 @@ public class PlayerWebApplicationTests : IAsyncLifetime
 
     // Note: the controller's 409 Conflict branch (squad number already exists) is
     // unreachable via the HTTP pipeline. The "Create" validation rule set includes
-    // BeUniqueSquadNumber, which returns a 400 validation error before the
-    // controller's own duplicate check ever runs. The 409 path is covered by the
-    // unit test Post_Players_Existing_Returns409Conflict, where validation is mocked
-    // to pass so the controller logic can be exercised in isolation.
+    // BeUniqueSquadNumber, which returns a 422 validation error (Unprocessable Entity)
+    // before the controller's own duplicate check ever runs. The 409 path is covered
+    // by the unit test Post_Players_Existing_Returns409Conflict, where validation is
+    // mocked to pass so the controller logic can be exercised in isolation.
 
     [Fact]
     [Trait("Category", "Integration")]

--- a/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
+++ b/test/Dotnet.Samples.AspNetCore.WebApi.Tests/Unit/PlayerControllerTests.cs
@@ -65,6 +65,16 @@ public class PlayerControllerTests : IDisposable
         );
         var httpResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
         httpResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        var problemDetails = httpResult
+            .ProblemDetails.Should()
+            .BeOfType<HttpValidationProblemDetails>()
+            .Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        problemDetails
+            .Errors.Should()
+            .ContainKey("SquadNumber")
+            .WhoseValue.Should()
+            .Contain("SquadNumber must be greater than 0.");
     }
 
     [Fact]
@@ -341,6 +351,16 @@ public class PlayerControllerTests : IDisposable
         );
         var httpResult = result.Should().BeOfType<ProblemHttpResult>().Subject;
         httpResult.StatusCode.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        var problemDetails = httpResult
+            .ProblemDetails.Should()
+            .BeOfType<HttpValidationProblemDetails>()
+            .Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
+        problemDetails
+            .Errors.Should()
+            .ContainKey("SquadNumber")
+            .WhoseValue.Should()
+            .Contain("SquadNumber must be greater than 0.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Follow-up to #479.

- Unit tests for `POST` and `PUT` validation errors now assert the full response payload: `ProblemDetails` is `HttpValidationProblemDetails`, `Status` equals 422, and `Errors` contains the expected field key and message
- Stale comment in the integration test updated to reflect that validation failures return 422, not 400
- CHANGELOG entry split into two sentences to separate the status-code rule from the Problem Details format attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now return HTTP 422 (Unprocessable Entity) instead of 400 (Bad Request), aligning with RFC 4918 standards.
  * Error responses follow RFC 9457 Problem Details format, providing detailed validation failure information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->