### PR TITLE
docs(changelog): prepare release notes for v2.1.2-frankfurt

### DIFF
--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -58,7 +58,15 @@ proceeding. Never create a branch, commit, tag, or push without approval.
      - `[unreleased]` → `.../compare/vX.Y.Z-{stadium}...HEAD`
      - Add `[X.Y.Z - StadiumName]` → `.../compare/v{prev-tag}...vX.Y.Z-{stadium}`
 
-3. Show the full diff of `CHANGELOG.md` and propose this commit message:
+3. Show the full diff of `CHANGELOG.md`.
+
+4. If `coderabbit` CLI is installed, run `coderabbit review --type uncommitted --prompt-only`
+   on the uncommitted CHANGELOG changes:
+   - If actionable/serious findings are reported, stop and address them before proceeding.
+   - If only nitpick-level findings, report them and continue.
+   - If `coderabbit` is not installed, skip with a note.
+
+5. Propose this commit message:
 
    ```text
    docs(changelog): prepare release notes for vX.Y.Z-{stadium} (#issue)
@@ -66,15 +74,15 @@ proceeding. Never create a branch, commit, tag, or push without approval.
 
    **Wait for explicit approval before committing.**
 
-4. Run `/pre-commit`, manually skipping step 1 — do not re-run or re-attempt
-   the CHANGELOG update; it was already completed above. Open with: "Skip
-   step 1 — CHANGELOG was already updated as part of this release branch."
-   Proceed directly with steps 2–5.
+6. Run `/pre-commit`, manually skipping step 1 and step 5 — the CHANGELOG update
+   and CodeRabbit review were already completed above. Open with: "Skip step 1
+   (CHANGELOG already updated) and step 5 (CodeRabbit already run) — proceeding
+   with steps 2–4."
 
-5. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
+7. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
    **Wait for explicit approval before opening.**
 
-6. Open the PR with:
+8. Open the PR with:
    - Title: `docs(changelog): prepare release notes for vX.Y.Z-{stadium}`
    - Body summarising what is included in this release.
 

--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -81,10 +81,12 @@ proceeding. Never create a branch, commit, tag, or push without approval.
 8. If `dotnet csharpier` is available, run `dotnet csharpier --check .` — must pass
    (run `dotnet csharpier .` to auto-fix). Skip with a note if not installed.
 
-9. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
-   **Wait for explicit approval before opening.**
+9. Stage `CHANGELOG.md` and commit using the approved message from step 5.
 
-10. Open the PR with:
+10. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
+    **Wait for explicit approval before opening.**
+
+11. Open the PR with:
    - Title: `docs(changelog): prepare release notes for vX.Y.Z-{stadium}`
    - Body summarising what is included in this release.
 

--- a/.claude/commands/pre-release.md
+++ b/.claude/commands/pre-release.md
@@ -74,15 +74,17 @@ proceeding. Never create a branch, commit, tag, or push without approval.
 
    **Wait for explicit approval before committing.**
 
-6. Run `/pre-commit`, manually skipping step 1 and step 5 — the CHANGELOG update
-   and CodeRabbit review were already completed above. Open with: "Skip step 1
-   (CHANGELOG already updated) and step 5 (CodeRabbit already run) — proceeding
-   with steps 2–4."
+6. Run `dotnet build --configuration Release` — must succeed.
 
-7. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
+7. Run `dotnet test --settings .runsettings` — all tests must pass.
+
+8. If `dotnet csharpier` is available, run `dotnet csharpier --check .` — must pass
+   (run `dotnet csharpier .` to auto-fix). Skip with a note if not installed.
+
+9. Propose opening a PR from `release/vX.Y.Z-{stadium}` into `master`.
    **Wait for explicit approval before opening.**
 
-8. Open the PR with:
+10. Open the PR with:
    - Title: `docs(changelog): prepare release notes for vX.Y.Z-{stadium}`
    - Body summarising what is included in this release.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,17 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Changed
 
-- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is now reserved for malformed requests (unparseable JSON, route/body mismatch); unsupported media types return `415 Unsupported Media Type` (RFC 9110 §15.5.16) via the `[Consumes]` attribute. Error responses follow the Problem Details format (RFC 9457).
-
 ### Fixed
+
+### Removed
+
+---
+
+## [2.1.2 - Frankfurt] - 2026-04-26
+
+### Changed
+
+- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is now reserved for malformed requests (unparseable JSON, route/body mismatch); unsupported media types return `415 Unsupported Media Type` (RFC 9110 §15.5.16) via the `[Consumes]` attribute. Error responses follow the Problem Details format (RFC 9457).
 
 ### Removed
 
@@ -207,7 +215,8 @@ Initial release. See [README.md](README.md) for complete feature list and docume
 
 ---
 
-[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.1-ekaterinburg...HEAD
+[unreleased]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.2-frankfurt...HEAD
+[2.1.2 - Frankfurt]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.1-ekaterinburg...v2.1.2-frankfurt
 [2.1.1 - Ekaterinburg]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.1.0-dusseldorf...v2.1.1-ekaterinburg
 [2.1.0 - Dusseldorf]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v2.0.0-centenario...v2.1.0-dusseldorf
 [2.0.0 - Centenario]: https://github.com/nanotaboada/Dotnet.Samples.AspNetCore.WebApi/compare/v1.1.0-bernabeu...v2.0.0-centenario


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` to `[2.1.2 - Frankfurt] - 2026-04-26` (patch release, letter F)
- Updates compare links in `CHANGELOG.md`
- Improves `/pre-release` command: CodeRabbit now runs before the commit (while changes are still uncommitted); build/test/format checks are inlined directly instead of delegating to `/pre-commit`

## What's in this release

### Changed
- Field validation failures now return `422 Unprocessable Entity` (RFC 4918) instead of `400 Bad Request`; `400 Bad Request` is reserved for malformed requests; unsupported media types return `415 Unsupported Media Type` via `[Consumes]`; error responses follow Problem Details format (RFC 9457)

### Removed
- `## How to Release` section removed from `CHANGELOG.md`; release codenames capitalized in version headers and reference links (#468)

## Test plan
- [ ] CI passes
- [ ] `CHANGELOG.md` diff looks correct
- [ ] Merge into `master`, then tag `v2.1.2-frankfurt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Version 2.1.2 - Frankfurt release documented with enhanced HTTP error response handling and standardized error format support.

* **Chores**
  * Updated pre-release workflow to include code review scanning, build verification, test execution, and code formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->