### PR TITLE
docs(claude-md): improve structure tree and workflow documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 
 ### Changed
 
+- Improved `CLAUDE.md` project guidance via the [CLAUDE.md Management plugin](https://claude.com/plugins/claude-md-management): added `Migrations/`, `Utilities/` (src) and `Integration/` (test) to the structure tree; documented `DATABASE_URL` Npgsql format, `STORAGE_PATH` SQLite path override, and exact `dotnet ef migrations add` commands for both providers; collapsed issue template bullets for conciseness; clarified `MigrateAsync()` runs automatically at startup.
 - `adr/` directory moved to `docs/adr/`; all references in `README.md`, `CONTRIBUTING.md`, and `.coderabbit.yaml` updated to the new path (issue #505).
 - `.coderabbit.yaml` controller path instruction updated: status code list corrected from `(200, 201, 400, 404, 409, 500)` to `(200, 201, 404, 409, 500)` with explicit note that FluentValidation failures must return 422 via `TypedResults.Problem(new HttpValidationProblemDetails(...))` (issue #505).
 - `.coderabbit.yaml` knowledge base guidelines updated from `.github/copilot-instructions.md` to `CLAUDE.md` and `docs/adr/README.md` (issue #505).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,12 @@ src/Dotnet.Samples.AspNetCore.WebApi/
 ├── Configurations/     — Options classes bound from appsettings.json
 ├── Middlewares/        — Custom ASP.NET Core middleware
 ├── Data/               — DbContext; seed data via HasData() in OnModelCreating
-└── Storage/            — SQLite database file (created at runtime by MigrateAsync)
+├── Migrations/         — EF Core migrations; Npgsql/ subdirectory for PostgreSQL provider
+├── Utilities/          — Internal helpers: HttpContext, Swagger, PlayerData seed source
+└── Storage/            — SQLite database file (runtime-generated, gitignored)
 
 test/Dotnet.Samples.AspNetCore.WebApi.Tests/
+├── Integration/        — Repository and WebApplication integration tests
 ├── Unit/               — Unit tests (controllers, services, validators)
 └── Utilities/          — Shared test helpers: PlayerFakes, PlayerMocks, PlayerStubs
 ```
@@ -193,28 +196,25 @@ Example: `feat(api): add player search endpoint (#123)`
 
 This project uses Spec-Driven Development (SDD): discuss in Plan mode first, create a GitHub Issue as the spec artifact, then implement. Always offer to draft an issue before writing code.
 
-**Feature request** (`enhancement` label):
-- **Problem**: the pain point being solved
-- **Proposed Solution**: expected behavior and functionality
-- **Suggested Approach** *(optional)*: implementation plan if known
-- **Acceptance Criteria**: at minimum — behaves as proposed, tests added/updated, no regressions
-- **References**: related issues, docs, or examples
+**Feature request** (`enhancement` label): Problem · Proposed Solution · Suggested Approach (optional) · Acceptance Criteria · References
 
-**Bug report** (`bug` label):
-- **Description**: clear summary of the bug
-- **Steps to Reproduce**: numbered, minimal steps
-- **Expected / Actual Behavior**: one section each
-- **Environment**: runtime versions + OS
-- **Additional Context**: logs, screenshots, stack traces
-- **Possible Solution** *(optional)*: suggested fix or workaround
+**Bug report** (`bug` label): Description · Steps to Reproduce · Expected/Actual Behavior · Environment · Additional Context · Possible Solution (optional)
 
 ### Key workflows
 
 **Add an endpoint**: Add DTO in `Models/` → update `PlayerMappingProfile` in `Mappings/` → add repository method(s) in `Repositories/` → add service method in `Services/` → add controller action in `Controllers/` → add/update validator rule set in `Validators/` → add tests in `test/.../Unit/` → run pre-commit checks.
 
-**Modify schema**: Update `Player` entity → update DTOs → update AutoMapper profile → update `HasData()` seed data in `OnModelCreating` if needed → run `dotnet ef migrations add <Name>` twice (once for each provider: output goes to `Migrations/` for SQLite, `Migrations/Npgsql/` for PostgreSQL) → update tests → run `dotnet test`.
+**Modify schema**: Update `Player` entity → update DTOs → update AutoMapper profile → update `HasData()` seed data in `OnModelCreating` if needed → add migrations for both providers → update tests → run `dotnet test`.
 
-**Switch database provider**: Set `DATABASE_PROVIDER=postgres` (plus `DATABASE_URL`) to use PostgreSQL, or leave unset for SQLite (default). `ProviderSpecificMigrationsAssembly` filters migration discovery to the active provider's namespace at runtime — no code changes needed to switch.
+```bash
+# SQLite migration (default)
+dotnet ef migrations add <Name> --project src/Dotnet.Samples.AspNetCore.WebApi
+# PostgreSQL migration
+DATABASE_PROVIDER=postgres DATABASE_URL="Host=localhost;..." \
+  dotnet ef migrations add <Name> --project src/Dotnet.Samples.AspNetCore.WebApi --output-dir Migrations/Npgsql
+```
+
+**Switch database provider**: Set `DATABASE_PROVIDER=postgres` (plus `DATABASE_URL`) to use PostgreSQL, or leave unset for SQLite (default). `DATABASE_URL` follows the Npgsql convention: `Host=...;Database=...;Username=...;Password=...`. For SQLite, `STORAGE_PATH` overrides the default database file path (`AppContext.BaseDirectory/storage/players-sqlite3.db`). `ProviderSpecificMigrationsAssembly` filters migration discovery to the active provider's namespace at runtime — no code changes needed to switch. Migrations run automatically at startup via `MigrateAsync()`; no manual `dotnet ef database update` is required.
 
 ## Invariants (never change without explicit discussion)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,13 @@ DATABASE_PROVIDER=postgres DATABASE_URL="Host=localhost;..." \
   dotnet ef migrations add <Name> --project src/Dotnet.Samples.AspNetCore.WebApi --output-dir Migrations/Npgsql
 ```
 
-**Switch database provider**: Set `DATABASE_PROVIDER=postgres` (plus `DATABASE_URL`) to use PostgreSQL, or leave unset for SQLite (default). `DATABASE_URL` follows the Npgsql convention: `Host=...;Database=...;Username=...;Password=...`. For SQLite, `STORAGE_PATH` overrides the default database file path (`AppContext.BaseDirectory/storage/players-sqlite3.db`). `ProviderSpecificMigrationsAssembly` filters migration discovery to the active provider's namespace at runtime — no code changes needed to switch. Migrations run automatically at startup via `MigrateAsync()`; no manual `dotnet ef database update` is required.
+**Switch database provider**:
+
+- Set `DATABASE_PROVIDER=postgres` to use PostgreSQL, or leave unset for SQLite (default).
+- `DATABASE_URL` (required for PostgreSQL) follows the Npgsql convention: `Host=...;Database=...;Username=...;Password=...`.
+- For SQLite, `STORAGE_PATH` overrides the default file path (`AppContext.BaseDirectory/storage/players-sqlite3.db`).
+- `ProviderSpecificMigrationsAssembly` filters migration discovery to the active provider's namespace at runtime — no code changes needed to switch.
+- Migrations run automatically at startup via `MigrateAsync()`; no manual `dotnet ef database update` is required.
 
 ## Invariants (never change without explicit discussion)
 


### PR DESCRIPTION
## Summary

- Fixes structure tree to reflect actual filesystem: adds `Migrations/`, `Utilities/` (src) and `Integration/` (test); clarifies `Storage/` as runtime-generated and gitignored
- Replaces vague "run twice" prose in Modify schema workflow with exact `dotnet ef migrations add` commands for both providers
- Documents `DATABASE_URL` Npgsql format and previously-undocumented `STORAGE_PATH` env var override for SQLite path
- Clarifies `MigrateAsync()` runs automatically at startup — no manual `dotnet ef database update` required after switching providers
- Collapses issue template field bullets into compact single-line references (12 lines → 2 lines)

> Improvements generated by the [CLAUDE.md Management plugin](https://claude.com/plugins/claude-md-management).

## Test plan

- [ ] `CLAUDE.md` structure tree matches `ls src/` and `ls test/`
- [ ] Migration commands in Modify schema workflow are copy-paste ready for both providers
- [ ] No regressions in other sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation with improved organization of key directories and components.
  * Enhanced issue templates for feature requests and bug reports.
  * Clarified database migration workflows and how migrations are applied at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->