### PR TITLE
docs(adr): add full-replace PUT, AI workflow and SDD records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ This project uses famous football stadiums (A-Z) that hosted FIFA World Cup matc
 - `.env.example` documenting `DATABASE_PROVIDER`, `DATABASE_URL`, and `POSTGRES_PASSWORD`.
 - `.env` added to `.gitignore`.
 - ADR-0014 (`docs/adr/0014-configurable-database-provider.md`) documenting the decision; supersedes ADR-0003.
+- ADR-0015: Use Full-Replace PUT as the Partial Update Strategy
+- ADR-0016: Adopt AI-Assisted Development Workflow
+- ADR-0017: Adopt Spec-Driven Development (SDD)
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,5 @@
 # CLAUDE.md
 
-## Claude Code
-
-- Run `/pre-commit` to execute the full pre-commit checklist for this project.
-
 ## Overview
 
 REST API for managing football players built with ASP.NET Core 10. Implements CRUD operations with a layered architecture, EF Core persistence (SQLite by default, PostgreSQL opt-in via `DATABASE_PROVIDER`), FluentValidation, AutoMapper, and in-memory caching. Primarily a learning and reference project — clarity and educational value take precedence over brevity.
@@ -232,7 +228,7 @@ DATABASE_PROVIDER=postgres DATABASE_URL="Host=localhost;..." \
 
 ## Architecture Decision Records
 
-Significant architectural decisions are documented in `docs/adr/` (ADR-0001–0014).
+Significant architectural decisions are documented in `docs/adr/` (ADR-0001–0017).
 
 Load `#file:docs/adr/README.md` when:
 - The user asks about architectural choices or "why we use X"
@@ -248,3 +244,7 @@ feat(scope): description (#issue)
 
 Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
+
+## Claude Code
+
+- Run `/pre-commit` to execute the full pre-commit checklist for this project.

--- a/docs/adr/0015-use-full-replace-put-no-patch.md
+++ b/docs/adr/0015-use-full-replace-put-no-patch.md
@@ -1,0 +1,46 @@
+# 0015. Use Full-Replace PUT as the Partial Update Strategy
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+HTTP defines two methods for updating an existing resource:
+
+- **PUT** — full replacement; the client sends the complete resource
+  representation, and the server replaces the stored state entirely
+- **PATCH** — partial update; the client sends only the changed fields
+
+Both are standard and well-understood. The choice affects API surface
+complexity, client implementation requirements, and server-side
+validation logic.
+
+## Decision
+
+We use PUT for all player update operations
+(`PUT /players/squadNumber/{n}`). The request body must contain the
+full player representation; the server replaces the stored resource
+entirely. No PATCH endpoint is provided at this time. A PATCH
+implementation is tracked in the project backlog and remains under
+active consideration.
+
+## Consequences
+
+### Positive
+- Simpler server-side implementation: a single validation path,
+  no partial-update merge logic
+- PUT semantics are idempotent and well-understood by API consumers
+- Consistent with all sibling repos in the cross-language comparison set
+
+### Negative
+- Clients must send the full resource representation even for
+  single-field changes
+- Fine-grained partial updates require a GET followed by a full PUT
+- PATCH tracked in backlog — if implemented, this ADR will be superseded
+
+### Neutral
+- Standard REST semantics; no ambiguity about the update contract
+  for current consumers

--- a/docs/adr/0015-use-full-replace-put-no-patch.md
+++ b/docs/adr/0015-use-full-replace-put-no-patch.md
@@ -30,17 +30,20 @@ active consideration.
 ## Consequences
 
 ### Positive
+
 - Simpler server-side implementation: a single validation path,
   no partial-update merge logic
 - PUT semantics are idempotent and well-understood by API consumers
 - Consistent with all sibling repos in the cross-language comparison set
 
 ### Negative
+
 - Clients must send the full resource representation even for
   single-field changes
 - Fine-grained partial updates require a GET followed by a full PUT
 - PATCH tracked in backlog — if implemented, this ADR will be superseded
 
 ### Neutral
+
 - Standard REST semantics; no ambiguity about the update contract
   for current consumers

--- a/docs/adr/0016-ai-assisted-development-workflow.md
+++ b/docs/adr/0016-ai-assisted-development-workflow.md
@@ -51,6 +51,7 @@ independent of the primary workflow.
 ## Consequences
 
 ### Positive
+
 - Stack-specific idioms are enforced by the agent's collective knowledge
   rather than individual developer discipline
 - `CLAUDE.md` is living architectural documentation: it must stay
@@ -60,6 +61,7 @@ independent of the primary workflow.
   than incidental
 
 ### Negative
+
 - Token economics: long-running work may exceed context limits, requiring
   active session management and continuation prompts to resume work
   across sessions
@@ -67,6 +69,7 @@ independent of the primary workflow.
   aligned; drift between them produces inconsistent agent behavior
 
 ### Neutral
+
 - Development workflow moves to the terminal/CLI rather than an IDE;
   this has no impact on the codebase itself
 - `CLAUDE.md` is specific to Claude Code; a different tool would require

--- a/docs/adr/0016-ai-assisted-development-workflow.md
+++ b/docs/adr/0016-ai-assisted-development-workflow.md
@@ -1,0 +1,73 @@
+# 0016. Adopt AI-Assisted Development Workflow
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+Software development has historically relied on three successive layers
+of knowledge:
+
+1. **Official documentation** — authoritative but static; describes the
+   intended API but not how real projects apply it
+2. **Community collaboration** — Stack Overflow, GitHub Discussions, blog
+   posts; describes how practitioners actually solve problems, but requires
+   the developer to synthesize and apply that knowledge themselves
+3. **AI synthesis** — models trained on both layers above, capable of
+   applying idiomatic, stack-specific knowledge directly to a given
+   codebase
+
+Agentic AI tools represent a qualitative shift: instead of consulting
+knowledge and applying it manually, the developer delegates implementation
+to an agent that has absorbed the collective idioms of a stack — "the
+Microsoft way", "the ASP.NET Core way" — and can apply them consistently.
+
+For a cross-language REST API comparison project, this matters
+particularly: each implementation should reflect how an experienced
+practitioner in that stack would structure the same problem, not a
+generic approach that happens to compile.
+
+Prior to Claude Code, AI assistance was used ad-hoc — pasting code into
+web interfaces (ChatGPT, DeepSeek) or via IDE-integrated assistants
+(GitHub Copilot). Both approaches lack persistent codebase context and
+the ability to act autonomously across a project.
+
+## Decision
+
+We adopt Claude Code as the primary development workflow tool for this
+project.
+
+A `CLAUDE.md` file at the repository root serves as the workflow
+specification: it documents architecture, coding conventions, invariants,
+and explicit boundaries for autonomous operation — what the agent may do
+freely, what requires human approval, and what must never be changed.
+
+CodeRabbit provides an additional automated code review layer
+independent of the primary workflow.
+
+## Consequences
+
+### Positive
+- Stack-specific idioms are enforced by the agent's collective knowledge
+  rather than individual developer discipline
+- `CLAUDE.md` is living architectural documentation: it must stay
+  accurate for the workflow to function, creating a natural incentive to
+  keep it current
+- Explicit autonomy boundaries make human oversight intentional rather
+  than incidental
+
+### Negative
+- Token economics: long-running work may exceed context limits, requiring
+  active session management and continuation prompts to resume work
+  across sessions
+- The global `~/.claude/CLAUDE.md` and per-repo `CLAUDE.md` must stay
+  aligned; drift between them produces inconsistent agent behavior
+
+### Neutral
+- Development workflow moves to the terminal/CLI rather than an IDE;
+  this has no impact on the codebase itself
+- `CLAUDE.md` is specific to Claude Code; a different tool would require
+  a different workflow specification format

--- a/docs/adr/0017-spec-driven-development.md
+++ b/docs/adr/0017-spec-driven-development.md
@@ -38,6 +38,7 @@ bumps) may skip the Issue step at the developer's discretion.
 ## Consequences
 
 ### Positive
+
 - Requirements are stated explicitly before implementation; the agent
   works against a written spec rather than an interpreted prompt
 - Issues survive session boundaries — a new session can resume from
@@ -46,12 +47,14 @@ bumps) may skip the Issue step at the developer's discretion.
   without relying on session memory
 
 ### Negative
+
 - Adds upfront overhead for changes that feel small; the Issue step can
   seem bureaucratic for straightforward work
 - The line between "spec-worthy" and "trivial" is judgment-dependent
   and not enforced by tooling
 
 ### Neutral
+
 - GitHub Issues double as the project backlog; SDD and backlog
   management share the same artifact
 - Plan mode discussion is ephemeral — not persisted outside the session;

--- a/docs/adr/0017-spec-driven-development.md
+++ b/docs/adr/0017-spec-driven-development.md
@@ -1,0 +1,58 @@
+# 0017. Adopt Spec-Driven Development (SDD)
+
+Date: 2026-06-10
+
+## Status
+
+Accepted
+
+## Context
+
+In an agentic development workflow, it is easy to begin implementation
+before requirements are fully understood. An AI assistant will produce
+working code from a vague prompt — but working and correct are not the
+same thing. Without a forcing function that requires requirements to be
+stated explicitly before implementation begins, scope creep, rework, and
+misaligned implementations are likely outcomes.
+
+GitHub Issues provide a natural spec artifact: persistent, linkable,
+and — critically — they survive session boundaries. In a workflow where
+context is lost between sessions, an Issue that captures the agreed
+approach and acceptance criteria before implementation begins serves as
+the durable contract between intent and implementation.
+
+## Decision
+
+All new features and non-trivial changes follow a three-step workflow:
+
+1. **Discuss** — describe the requirement in Claude Code Plan mode;
+   explore alternatives and consequences before committing to an approach
+2. **Specify** — create a GitHub Issue as the spec artifact, capturing
+   the agreed approach, acceptance criteria, and any constraints
+3. **Implement** — work against the Issue; commits reference it via
+   the `(#issue)` suffix in the Conventional Commits format
+
+Trivial changes (documentation updates, formatting fixes, dependency
+bumps) may skip the Issue step at the developer's discretion.
+
+## Consequences
+
+### Positive
+- Requirements are stated explicitly before implementation; the agent
+  works against a written spec rather than an interpreted prompt
+- Issues survive session boundaries — a new session can resume from
+  the Issue rather than reconstructing intent from scratch
+- The implementation trail (Issue → branch → PR → commit) is traceable
+  without relying on session memory
+
+### Negative
+- Adds upfront overhead for changes that feel small; the Issue step can
+  seem bureaucratic for straightforward work
+- The line between "spec-worthy" and "trivial" is judgment-dependent
+  and not enforced by tooling
+
+### Neutral
+- GitHub Issues double as the project backlog; SDD and backlog
+  management share the same artifact
+- Plan mode discussion is ephemeral — not persisted outside the session;
+  the Issue is the only durable record of the pre-implementation reasoning

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,9 @@ This directory contains Architecture Decision Records (ADRs) for this project. A
 | [0012](0012-use-stadium-themed-semantic-versioning.md) | Use Stadium-Themed Semantic Versioning | Accepted |
 | [0013](0013-testing-strategy.md) | Testing Strategy | Accepted |
 | [0014](0014-configurable-database-provider.md) | Configurable Database Provider | Accepted |
+| [0015](0015-use-full-replace-put-no-patch.md) | Use Full-Replace PUT as the Partial Update Strategy | Accepted |
+| [0016](0016-ai-assisted-development-workflow.md) | Adopt AI-Assisted Development Workflow | Accepted |
+| [0017](0017-spec-driven-development.md) | Adopt Spec-Driven Development (SDD) | Accepted |
 
 ## When to Create an ADR
 


### PR DESCRIPTION
## Summary

- ADR-0015: Documents the decision to use full-replace PUT (no PATCH) for player update operations
- ADR-0016: Documents the adoption of Claude Code as the primary AI-assisted development workflow tool
- ADR-0017: Documents the Spec-Driven Development (SDD) process — Plan → Issue → Implement

## Changes

- `docs/adr/0015-use-full-replace-put-no-patch.md` — new
- `docs/adr/0016-ai-assisted-development-workflow.md` — new
- `docs/adr/0017-spec-driven-development.md` — new
- `docs/adr/README.md` — index updated with ADR-0015–0017
- `CHANGELOG.md` — `[Unreleased]` section updated
- `CLAUDE.md` — ADR range updated to ADR-0001–0017; `## Claude Code` section moved to bottom

## Test plan

- [ ] ADR files render correctly on GitHub (headings, tables, code blocks)
- [ ] `docs/adr/README.md` index links resolve to the correct files
- [ ] No source code changes — build and tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added three new Architecture Decision Records (ADRs) covering: full-replace HTTP PUT approach for player updates, adoption of an AI-assisted development workflow, and a spec-driven development process.
  * Updated the project’s architecture documentation to include the newly added ADRs and expanded the documented ADR range, along with refreshed ADR index entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->